### PR TITLE
BIG RELEASE COMING UP HENCE THE CAPS LOCK, MAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 git-test
 
- 1. Create a few commits in  master
- 2. Create a develop branch off master
- 3. Create a feature branch off develop
- 4. Do a few commits on the feature branch.
- 5. Submit a PR for the feature against develop branch.
- 6. Approve the PR, squash and merge into develop.
- 7. Start a new feature branch.
- 8. Do a hotfix branch off master.
- 9. Make a couple of commits on the hotfix branch.
- 10. Submit a PR for hotfix against master branch.
- 11. Approve the PR, squash and merge it into the master.
- 12. Create a PR to merge master into develop.
- 13. Approve the PR and merge (no squash; but also there is no squash needed)
+ [x] Create a few commits in  master
+ [x] Create a develop branch off master
+ [x] Create a feature branch off develop
+ [x] Do a few commits on the feature branch.
+ [ ] Submit a PR for the feature against develop branch.
+ [ ] Approve the PR, squash and merge into develop.
+ [ ] Start a new feature branch.
+ [ ] Do a hotfix branch off master.
+ [ ] Make a couple of commits on the hotfix branch.
+ [ ] Submit a PR for hotfix against master branch.
+ [ ] Approve the PR, squash and merge it into the master.
+ [ ] Create a PR to merge master into develop.
+ [ ] Approve the PR and merge (no squash; but also there is no squash needed)
 

--- a/feature1.md
+++ b/feature1.md
@@ -1,0 +1,11 @@
+This is feature number one.
+I will be working on this feature in a branch called feature/f1
+This feature involves writing Lorem Ipsum level content, but not
+as beautiful because I am not a native speaker and because it
+is late too. And Lorem Ipsum has already been written numerous times.
+
+This is the second paragraph of the feature1 piece. I am adding it
+with a separate commit because I like to commit often to demonstrate 
+that I am a busy and important man.
+
+

--- a/feature2.md
+++ b/feature2.md
@@ -1,0 +1,5 @@
+Oh, happy days. I am already working on my second feature tonight.
+I am such a productive developer. I develop developments in git commits.
+
+And here comes the second commit in the second feature. Imagine how many commits will have the hundredth feature? A hundred?
+


### PR DESCRIPTION
Now develop cannot be squashed into master of course. No one was arguing for that.

This will be merged into master with "Merge pull request" ("Create a merge commit").

Since the conflict was resolved when merging master into develop, we should be fine now that develop is the source of truth on the contentious README.md file.